### PR TITLE
using an helper script for oh-my-zsh install + some container refactoring

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,5 +4,6 @@ RUN yarn global add @vue/cli
 
 RUN apk add git openssh zsh
 RUN sed -i 's/root:x:0:0:root:\/root:\/bin\/ash/root:x:0:0:root:\/root:\/bin\/zsh/g' /etc/passwd
-RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="minimal"/g' /root/.zshrc
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.1.5/zsh-in-docker.sh)" -- \
+    -t minimal \
+    -p git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,19 @@
 {
 	"name": "Vue registration form!",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 
-	"settings": { 
-		"terminal.integrated.profiles.linux": {
-			"zsh": {
-				"path": "zsh"
-			}
-		},
-		"terminal.integrated.defaultProfile.linux": "zsh"
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"eamodio.gitlens",
+				"mohsen1.prettify-json",
+				"ms-azuretools.vscode-docker"
+			]
+		}
 	},
-
-	"extensions": [
-		"eamodio.gitlens",
-		"mohsen1.prettify-json"
-	],
-
+	
 	"mounts": ["source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"],
 
 	"forwardPorts": [8080],


### PR DESCRIPTION
With this PR I'm going to rely on an [helper script](https://github.com/deluan/zsh-in-docker/) to take care of the [Oh My Zsh](https://ohmyz.sh/) installation inside the Docker image, and I'm refactoring a bit the structure of the `devcontainer.json` file.